### PR TITLE
Add Page model and PageTest

### DIFF
--- a/src/main/java/ar/edu/unc/david/routersimulator/model/Page.java
+++ b/src/main/java/ar/edu/unc/david/routersimulator/model/Page.java
@@ -1,0 +1,129 @@
+package ar.edu.unc.david.routersimulator.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents a logical message — the unit of data that a {@link Terminal} generates and sends.
+ *
+ * <p>A Page is fragmented into {@link Packet}s for transmission and reassembled at the destination.
+ * Equality is based solely on {@code pageId}
+ */
+public record Page(long pageId, int pageLen, IpAddress srcIp, IpAddress dstIp)
+    implements Comparable<Page> {
+
+  // =============== Compact Constructor ===============
+
+  /** Compact constructor that validates the input values for pageLen and srcIp/dstIp. */
+  public Page {
+    if (pageId < 0) {
+      throw new IllegalArgumentException("pageId must be non-negative, got: " + pageId);
+    }
+    if (pageLen <= 0) {
+      throw new IllegalArgumentException("pageLen must be > 0, got: " + pageLen);
+    }
+    if (!srcIp.isValid()) {
+      throw new IllegalArgumentException("srcIp must be valid (not 0.0)");
+    }
+    if (!dstIp.isValid()) {
+      throw new IllegalArgumentException("dstIp must be valid (not 0.0)");
+    }
+  }
+
+  // =============== Factory methods ===============
+
+  /**
+   * Rebuilds a Page from a list of Packets. Validates that all packets have consistent pageId,
+   * pageLen, srcIp, dstIp, and that their pagePos values are correct.
+   */
+  public static Page fromPackets(List<Packet> packets) {
+    if (packets == null || packets.isEmpty()) {
+      throw new IllegalArgumentException("Cannot create Page from empty packet list");
+    }
+
+    Packet first = packets.getFirst();
+    long pageId = first.pageId();
+    int pageLen = first.pageLen();
+    IpAddress src = first.srcIp();
+    IpAddress dst = first.dstIp();
+
+    if (packets.size() != pageLen) {
+      throw new IllegalArgumentException(
+          "Packet count (" + packets.size() + ") does not match pageLen (" + pageLen + ")");
+    }
+
+    for (int i = 0; i < packets.size(); i++) {
+      Packet p = packets.get(i);
+
+      if (p.pageId() != pageId) {
+        throw new IllegalArgumentException(
+            "Packet " + i + " has inconsistent pageId: " + p.pageId() + " vs " + pageId);
+      }
+      if (p.pageLen() != pageLen) {
+        throw new IllegalArgumentException("Packet " + i + " has inconsistent pageLen");
+      }
+      if (!p.srcIp().equals(src)) {
+        throw new IllegalArgumentException("Packet " + i + " has inconsistent srcIp");
+      }
+      if (!p.dstIp().equals(dst)) {
+        throw new IllegalArgumentException("Packet " + i + " has inconsistent dstIp");
+      }
+      if (p.pagePos() != i) {
+        throw new IllegalArgumentException(
+            "Packet at index " + i + " has wrong pagePos: " + p.pagePos());
+      }
+    }
+
+    return new Page(pageId, pageLen, src, dst);
+  }
+
+  // =============== toPackets ===============
+
+  /**
+   * Fragments this Page into a list of Packets for transmission. Each Packet will have the same
+   * pageId, pageLen, srcIp, dstIp, and a unique pagePos from 0 to pageLen-1. The currentTick is
+   * included in each Packet for timing purposes.
+   */
+  public List<Packet> toPackets(long currentTick) {
+    List<Packet> packets = new ArrayList<>(pageLen);
+    for (int pos = 0; pos < pageLen; pos++) {
+      packets.add(Packet.create(pageId, pos, pageLen, srcIp, dstIp, currentTick));
+    }
+    return packets;
+  }
+
+  // =============== Equality ===============
+
+  /** Equality is based solely on pageId. */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Page other)) {
+      return false;
+    }
+    return pageId == other.pageId;
+  }
+
+  /** Returns a hash code based on the pageId. */
+  @Override
+  public int hashCode() {
+    return Long.hashCode(pageId);
+  }
+
+  /** Natural ordering based on pageId. */
+  @Override
+  public int compareTo(Page other) {
+    return Long.compare(this.pageId, other.pageId);
+  }
+
+  // =============== toString ===============
+
+  /** Returns a string representation of the Page, including pageId, pageLen, and IP addresses. */
+  @Override
+  public @NotNull String toString() {
+    return String.format("Page{ID: %d | Len: %d | %s -> %s}", pageId, pageLen, srcIp, dstIp);
+  }
+}

--- a/src/test/java/ar/edu/unc/david/routersimulator/model/PageTest.java
+++ b/src/test/java/ar/edu/unc/david/routersimulator/model/PageTest.java
@@ -1,0 +1,187 @@
+package ar.edu.unc.david.routersimulator.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PageTest {
+
+  private static final IpAddress SRC = new IpAddress(1, 1);
+  private static final IpAddress DST = new IpAddress(2, 1);
+
+  // =============== Constructor básico ===============
+
+  @Test
+  void constructor_storesFields() {
+    var page = new Page(1L, 5, SRC, DST);
+    assertEquals(1L, page.pageId());
+    assertEquals(5, page.pageLen());
+    assertEquals(SRC, page.srcIp());
+    assertEquals(DST, page.dstIp());
+  }
+
+  @Test
+  void constructor_throwsOnInvalidPageId() {
+    assertThrows(IllegalArgumentException.class, () -> new Page(-1L, 3, SRC, DST));
+  }
+
+  @Test
+  void constructor_throwsOnZeroOrNegativeLen() {
+    assertThrows(IllegalArgumentException.class, () -> new Page(1L, 0, SRC, DST));
+    assertThrows(IllegalArgumentException.class, () -> new Page(1L, -1, SRC, DST));
+  }
+
+  @Test
+  void constructor_throwsOnInvalidIps() {
+    assertThrows(IllegalArgumentException.class, () -> new Page(1L, 3, IpAddress.INVALID, DST));
+    assertThrows(IllegalArgumentException.class, () -> new Page(1L, 3, SRC, IpAddress.INVALID));
+  }
+
+  // =============== fromPackets ===============
+
+  @Test
+  void fromPackets_throwsOnEmptyList() {
+    assertThrows(IllegalArgumentException.class, () -> Page.fromPackets(List.of()));
+    assertThrows(IllegalArgumentException.class, () -> Page.fromPackets(null));
+  }
+
+  @Test
+  void fromPackets_throwsOnWrongPacketCount() {
+    var packets = new Page(1L, 3, SRC, DST).toPackets(0L);
+    assertThrows(IllegalArgumentException.class, () -> Page.fromPackets(packets.subList(0, 2)));
+  }
+
+  @Test
+  void fromPackets_throwsOnWrongPageId() {
+    var p0 = Packet.create(1L, 0, 2, SRC, DST, 0L);
+    var p1 = Packet.create(2L, 0, 2, SRC, DST, 0L);
+    assertThrows(IllegalArgumentException.class, () -> Page.fromPackets(List.of(p0, p1)));
+  }
+
+  @Test
+  void fromPackets_throwsOnWrongPageLen() {
+    var p0 = Packet.create(1L, 0, 2, SRC, DST, 0L);
+    var p1 = Packet.create(1L, 0, 3, SRC, DST, 0L);
+    assertThrows(IllegalArgumentException.class, () -> Page.fromPackets(List.of(p0, p1)));
+  }
+
+  @Test
+  void fromPackets_throwsOnWrongSrcIp() {
+    var p0 = Packet.create(1L, 0, 2, SRC, DST, 0L);
+    var p1 = Packet.create(1L, 0, 2, DST, DST, 0L);
+    assertThrows(IllegalArgumentException.class, () -> Page.fromPackets(List.of(p0, p1)));
+  }
+
+  @Test
+  void fromPackets_throwsOnWrongDstIp() {
+    var p0 = Packet.create(1L, 0, 2, SRC, DST, 0L);
+    var p1 = Packet.create(1L, 0, 2, SRC, SRC, 0L);
+    assertThrows(IllegalArgumentException.class, () -> Page.fromPackets(List.of(p0, p1)));
+  }
+
+  @Test
+  void fromPackets_throwsOnWrongPagePos() {
+    var p0 = Packet.create(1L, 0, 3, SRC, DST, 0L);
+    var p1 = Packet.create(1L, 2, 3, SRC, DST, 0L); // pos=2 donde debería ir pos=1
+    var p2 = Packet.create(1L, 1, 3, SRC, DST, 0L);
+    assertThrows(IllegalArgumentException.class, () -> Page.fromPackets(List.of(p0, p1, p2)));
+  }
+
+  // =============== toPackets ===============
+
+  @Test
+  void toPackets_generatesCorrectCount() {
+    var page = new Page(7L, 4, SRC, DST);
+    var packets = page.toPackets(10L);
+    assertEquals(4, packets.size());
+  }
+
+  @Test
+  void toPackets_positionsAreSequential() {
+    var packets = new Page(1L, 3, SRC, DST).toPackets(0L);
+    for (int i = 0; i < packets.size(); i++) {
+      assertEquals(i, packets.get(i).pagePos());
+    }
+  }
+
+  @Test
+  void toPackets_firstAndLastFlagsCorrect() {
+    var packets = new Page(1L, 3, SRC, DST).toPackets(0L);
+    assertTrue(packets.getFirst().isFirstPacket());
+    assertTrue(packets.getLast().isLastPacket());
+    assertFalse(packets.get(1).isFirstPacket());
+    assertFalse(packets.get(1).isLastPacket());
+  }
+
+  @Test
+  void toPackets_expiryTickIsCurrentPlusTtl() {
+    long currentTick = 42L;
+    var packet = new Page(1L, 1, SRC, DST).toPackets(currentTick).getFirst();
+    assertEquals(currentTick + Packet.TTL, packet.expiryTick());
+  }
+
+  @Test
+  void toPackets_roundTrip() {
+    var original = new Page(5L, 3, SRC, DST);
+    var packets = original.toPackets(0L);
+    var restored = Page.fromPackets(packets);
+    assertEquals(original.pageId(), restored.pageId());
+    assertEquals(original.pageLen(), restored.pageLen());
+  }
+
+  // =============== Equality & Comparable ===============
+
+  @Test
+  void equals_basedOnlyOnPageId() {
+    var p1 = new Page(42L, 3, SRC, DST);
+    var p2 = new Page(42L, 5, DST, SRC); // distinto len, src, dst
+    assertEquals(p1, p2);
+  }
+
+  @Test
+  void equals_differentPageIdsNotEqual() {
+    var p1 = new Page(1L, 3, SRC, DST);
+    var p2 = new Page(2L, 3, SRC, DST);
+    assertNotEquals(p1, p2);
+  }
+
+  @Test
+  void equals_sameObject_true() {
+    var p = new Page(42L, 3, SRC, DST);
+    var q = p;
+    assertEquals(p, q);
+  }
+
+  @Test
+  void equals_differentClass_false() {
+    var p = new Page(42L, 3, SRC, DST);
+    var q = new Object();
+    assertNotEquals(p, q);
+  }
+
+  @Test
+  void hashCode_basedOnPageId() {
+    var p1 = new Page(42L, 3, SRC, DST);
+    var p2 = new Page(42L, 5, DST, SRC);
+    assertEquals(p1.hashCode(), p2.hashCode());
+  }
+
+  @Test
+  void compareTo_ordersByPageId() {
+    var low = new Page(1L, 1, SRC, DST);
+    var high = new Page(2L, 1, SRC, DST);
+    assertTrue(low.compareTo(high) < 0);
+    assertTrue(high.compareTo(low) > 0);
+  }
+
+  @Test
+  void toString_matchesExpectedFormat() {
+    var page = new Page(3L, 4, SRC, DST);
+    assertEquals("Page{ID: 3 | Len: 4 | 001.001 -> 002.001}", page.toString());
+  }
+}


### PR DESCRIPTION
This pull request introduces a new `Page` class to the router simulator model, representing a logical message that can be fragmented into packets for transmission and reassembled at the destination. It also adds a comprehensive test suite for the `Page` class to ensure correctness and robustness. The main changes are grouped into model implementation and testing.

Model implementation:

* Added a new `Page` record in `Page.java` with fields for `pageId`, `pageLen`, `srcIp`, and `dstIp`, including validation in the compact constructor.
* Implemented factory method `fromPackets` for reconstructing a `Page` from a list of `Packet`s, with thorough validation of packet consistency.
* Provided `toPackets` method to fragment a `Page` into a list of `Packet`s for transmission, assigning sequential positions and including timing information.
* Defined equality, hash code, and natural ordering based solely on `pageId`, and a formatted `toString` method for easy debugging.

Testing:

* Added `PageTest.java` with extensive unit tests covering constructor validation, packet fragmentation and reassembly, equality and comparison, and string representation.