### PR TITLE
Feat/reassembler

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,11 @@ checkstyle {
     configProperties = mapOf("org.checkstyle.google.suppressionfilter.config" to "")
 }
 
+tasks.check {
+    dependsOn(tasks.named("checkstyleMain"))
+    dependsOn(tasks.named("checkstyleTest"))
+}
+
 spotless {
     java {
 

--- a/src/main/java/ar/edu/unc/david/routersimulator/service/PageReassembler.java
+++ b/src/main/java/ar/edu/unc/david/routersimulator/service/PageReassembler.java
@@ -1,0 +1,177 @@
+package ar.edu.unc.david.routersimulator.service;
+
+import ar.edu.unc.david.routersimulator.model.IpAddress;
+import ar.edu.unc.david.routersimulator.model.Packet;
+import ar.edu.unc.david.routersimulator.model.Page;
+import java.util.List;
+
+/**
+ * Collects incoming {@link Packet}s for a single {@link Page} and detects completion.
+ *
+ * <p>Each slot in the internal array corresponds to a packet position. A null slot means the packet
+ * hasn't arrived yet. Once all slots are filled, {@link #isComplete()} returns true and {@link
+ * #assemble()} can be called to reconstruct the Page.
+ *
+ * <p>The {@code expiryTick} is an absolute simulation tick — the Terminal checks it externally to
+ * decide whether to discard this reassembler.
+ */
+public class PageReassembler {
+
+  public static final int MAX_TTL = 250;
+
+  private final long pageId;
+  private final IpAddress srcIp;
+  private final long expiryTick;
+  private final Packet[] slots;
+  private int count;
+
+  // =============== Constructor ===============
+  /** Initializes a new PageReassembler for the given pageId, srcIp, and total packet count. */
+  public PageReassembler(long pageId, IpAddress srcIp, int total, long currentTick) {
+    if (pageId < 0) {
+      throw new IllegalArgumentException("pageId must be non-negative, got: " + pageId);
+    }
+    if (total <= 0) {
+      throw new IllegalArgumentException("total must be > 0, got: " + total);
+    }
+    if (!srcIp.isValid()) {
+      throw new IllegalArgumentException("srcIp must be valid");
+    }
+    if (currentTick < 0) {
+      throw new IllegalArgumentException("currentTick must be non-negative, got: " + currentTick);
+    }
+
+    this.pageId = pageId;
+    this.srcIp = srcIp;
+    this.expiryTick = currentTick + MAX_TTL;
+    this.slots = new Packet[total];
+    this.count = 0;
+  }
+
+  // =============== Getters ===============
+
+  public long pageId() {
+    return pageId;
+  }
+
+  public IpAddress srcIp() {
+    return srcIp;
+  }
+
+  public int total() {
+    return slots.length;
+  }
+
+  public long expiryTick() {
+    return expiryTick;
+  }
+
+  public int count() {
+    return count;
+  }
+
+  public int remaining() {
+    return slots.length - count;
+  }
+
+  public double completionRate() {
+    return (double) count / slots.length;
+  }
+
+  public boolean isComplete() {
+    return count == slots.length;
+  }
+
+  public boolean isExpired(long currTick) {
+    return currTick >= expiryTick;
+  }
+
+  /**
+   * Checks if the packet at the given position has been received.
+   *
+   * @param position Must be in [0, total).
+   */
+  public boolean hasPacketAt(int position) {
+    if (position < 0 || position >= slots.length) {
+      throw new IndexOutOfBoundsException("Position out of range: " + position);
+    }
+    return slots[position] != null;
+  }
+
+  // =============== Modifiers ===============
+
+  /**
+   * Tries to add a packet to this reassembler. The packet must match the pageId, srcIp, and total
+   * packet count of this reassembler. The packet's pagePos must be a valid index and not already
+   * occupied.
+   *
+   * @return true if the packet was successfully added, false if it was rejected.
+   */
+  public boolean addPacket(Packet p) {
+    if (p.pageId() != pageId) {
+      return false;
+    }
+    if (!p.srcIp().equals(srcIp)) {
+      return false;
+    }
+    if (p.pageLen() != slots.length) {
+      return false;
+    }
+
+    int pos = p.pagePos();
+
+    if (slots[pos] != null) {
+      return false;
+    }
+
+    slots[pos] = p;
+    count++;
+    return true;
+  }
+
+  /**
+   * Assembles the complete page from the collected packets. This should only be called if {@link
+   * #isComplete()} returns true, otherwise an exception is thrown. After assembly, the reassembler
+   * is reset to an empty state, allowing it to be reused for a new page if desired. The returned
+   * list of packets is immutable and ordered by page position.
+   *
+   * @throws IllegalStateException if the page is not yet complete.
+   */
+  public Page assemble() {
+    if (!isComplete()) {
+      throw new IllegalStateException(
+          "Cannot assemble incomplete page: " + count + "/" + slots.length);
+    }
+
+    List<Packet> result = List.of(slots);
+
+    return Page.fromPackets(result);
+  }
+
+  // =============== Equality ===============
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PageReassembler other)) {
+      return false;
+    }
+    return pageId == other.pageId;
+  }
+
+  @Override
+  public int hashCode() {
+    return Long.hashCode(pageId);
+  }
+
+  // =============== toString ===============
+
+  @Override
+  public String toString() {
+    return String.format(
+        "PageReassembler{ID: %d | srcIp: %s | %d/%d packets | Expiry: %d}",
+        pageId, srcIp, count, slots.length, expiryTick);
+  }
+}

--- a/src/test/java/ar/edu/unc/david/routersimulator/service/PageReassemblerTest.java
+++ b/src/test/java/ar/edu/unc/david/routersimulator/service/PageReassemblerTest.java
@@ -1,0 +1,188 @@
+package ar.edu.unc.david.routersimulator.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ar.edu.unc.david.routersimulator.model.IpAddress;
+import ar.edu.unc.david.routersimulator.model.Packet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PageReassemblerTest {
+
+  private static final IpAddress SRC = new IpAddress(1, 1);
+  private static final IpAddress DST = new IpAddress(2, 1);
+  private static final long PAGE_ID = 7L;
+  private static final int TOTAL = 3;
+
+  private PageReassembler reassembler;
+
+  @BeforeEach
+  void setUp() {
+    reassembler = new PageReassembler(PAGE_ID, SRC, TOTAL, 0L);
+  }
+
+  // =============== Constructor ===============
+
+  @Test
+  void constructor_throwsOnNegativePageId() {
+    assertThrows(IllegalArgumentException.class, () -> new PageReassembler(-1L, SRC, TOTAL, 0L));
+  }
+
+  @Test
+  void constructor_throwsOnZeroOrNegativeTotal() {
+    assertThrows(IllegalArgumentException.class, () -> new PageReassembler(PAGE_ID, SRC, 0, 0L));
+    assertThrows(IllegalArgumentException.class, () -> new PageReassembler(PAGE_ID, SRC, -1, 0L));
+  }
+
+  @Test
+  void constructor_throwsOnInvalidSrcIp() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PageReassembler(PAGE_ID, IpAddress.INVALID, TOTAL, 0L));
+  }
+
+  @Test
+  void constructor_throwsOnInvalidExpiryTick() {
+    assertThrows(
+        IllegalArgumentException.class, () -> new PageReassembler(PAGE_ID, SRC, TOTAL, -1L));
+  }
+
+  // =============== Initial state ===============
+
+  @Test
+  void initialState_noPacketsReceived() {
+    assertEquals(PAGE_ID, reassembler.pageId());
+    assertEquals(SRC, reassembler.srcIp());
+    assertEquals(TOTAL, reassembler.total());
+    assertEquals(250L, reassembler.expiryTick());
+    assertEquals(0, reassembler.count());
+    assertEquals(TOTAL, reassembler.remaining());
+    assertEquals(0.0, reassembler.completionRate());
+    assertFalse(reassembler.isComplete());
+  }
+
+  @Test
+  void expiryTick_isCurrentPlusMaxTtl() {
+    long tick = 50L;
+    var r = new PageReassembler(1L, SRC, 3, tick);
+    assertEquals(tick + PageReassembler.MAX_TTL, r.expiryTick());
+  }
+
+  @Test
+  void isExpired_falseBeforeExpiryTick() {
+    assertFalse(reassembler.isExpired(PageReassembler.MAX_TTL - 1));
+  }
+
+  @Test
+  void isExpired_trueAtOrAfterExpiryTick() {
+    assertTrue(reassembler.isExpired(PageReassembler.MAX_TTL));
+    assertTrue(reassembler.isExpired(PageReassembler.MAX_TTL + 1));
+  }
+
+  // =============== addPacket ===============
+
+  @Test
+  void addPacket_acceptsValidPacket() {
+    var p = Packet.create(PAGE_ID, 0, TOTAL, SRC, DST, 0L);
+    assertTrue(reassembler.addPacket(p));
+    assertEquals(1, reassembler.count());
+    assertTrue(reassembler.hasPacketAt(0));
+  }
+
+  @Test
+  void addPacket_rejectsDuplicateSlot() {
+    var p = Packet.create(PAGE_ID, 0, TOTAL, SRC, DST, 0L);
+    reassembler.addPacket(p);
+    assertFalse(reassembler.addPacket(p));
+    assertEquals(1, reassembler.count());
+  }
+
+  @Test
+  void addPacket_rejectsWrongPageId() {
+    var p = Packet.create(999L, 0, TOTAL, SRC, DST, 0L);
+    assertFalse(reassembler.addPacket(p));
+  }
+
+  @Test
+  void addPacket_rejectsWrongSrcIp() {
+    var other = new IpAddress(9, 9);
+    var p = Packet.create(PAGE_ID, 0, TOTAL, other, DST, 0L);
+    assertFalse(reassembler.addPacket(p));
+  }
+
+  @Test
+  void addPacket_rejectsWrongPageLen() {
+    var p = Packet.create(PAGE_ID, 0, 1, SRC, DST, 0L);
+    assertFalse(reassembler.addPacket(p));
+  }
+
+  // =============== isComplete / completionRate ===============
+
+  @Test
+  void isComplete_afterAllPacketsAdded() {
+    for (int i = 0; i < TOTAL; i++) {
+      reassembler.addPacket(Packet.create(PAGE_ID, i, TOTAL, SRC, DST, 0L));
+    }
+
+    assertTrue(reassembler.isComplete());
+    assertEquals(1.0, reassembler.completionRate());
+  }
+
+  // =============== assemble ===============
+
+  @Test
+  void assemble_returnsPageWhenComplete() {
+    for (int i = 0; i < TOTAL; i++) {
+      reassembler.addPacket(Packet.create(PAGE_ID, i, TOTAL, SRC, DST, 0L));
+    }
+
+    var page = reassembler.assemble();
+    assertEquals(PAGE_ID, page.pageId());
+    assertEquals(TOTAL, page.pageLen());
+    assertEquals(SRC, page.srcIp());
+    assertEquals(DST, page.dstIp());
+  }
+
+  @Test
+  void assemble_throwsIfIncomplete() {
+    reassembler.addPacket(Packet.create(PAGE_ID, 0, TOTAL, SRC, DST, 0L));
+    assertThrows(IllegalStateException.class, () -> reassembler.assemble());
+  }
+
+  // =============== Equality ===============
+
+  @Test
+  void equals_trueForSameObject() {
+    assertEquals(reassembler, reassembler);
+  }
+
+  @Test
+  void equals_falseForDifferentType() {
+    Object o = new Object();
+    assertNotEquals(reassembler, o);
+  }
+
+  @Test
+  void equals_basedOnlyOnPageId() {
+    var other = new PageReassembler(PAGE_ID, new IpAddress(9, 9), 5, 999L);
+    assertEquals(reassembler, other);
+  }
+
+  // =============== hashCode ===============
+  @Test
+  void hashCode_basedOnPageId() {
+    assertEquals(reassembler.hashCode(), new PageReassembler(PAGE_ID, SRC, TOTAL, 0L).hashCode());
+  }
+
+  // =============== toString ===============
+  @Test
+  void toString_matchesExpectedFormat() {
+    assertEquals(
+        "PageReassembler{ID: 7 | srcIp: 001.001 | 0/3 packets | Expiry: 250}",
+        reassembler.toString());
+  }
+}


### PR DESCRIPTION
This pull request introduces a new `PageReassembler` class to the router simulator and provides comprehensive unit tests for its behavior. The `PageReassembler` is responsible for collecting packets belonging to a single page, detecting when all packets have arrived, and assembling them into a complete page. The tests cover all key aspects of its functionality and edge cases.

Core functionality:  
**Page reassembly and management**

* Added the `PageReassembler` class, which tracks packets for a specific page, manages their positions, detects completion, and assembles the page when all packets are received. Includes expiry logic based on simulation ticks. (`src/main/java/ar/edu/unc/david/routersimulator/service/PageReassembler.java`)

Testing and validation:  
**Unit tests for correctness**

* Added `PageReassemblerTest` with thorough coverage, including constructor validation, packet addition and rejection, completion detection, expiry checks, equality, hash code, and string representation. (`src/test/java/ar/edu/unc/david/routersimulator/service/PageReassemblerTest.java`)