### PR TITLE
Feat/packetbuffer

### DIFF
--- a/src/main/java/ar/edu/unc/david/routersimulator/model/infrastructure/PacketBuffer.java
+++ b/src/main/java/ar/edu/unc/david/routersimulator/model/infrastructure/PacketBuffer.java
@@ -1,0 +1,178 @@
+package ar.edu.unc.david.routersimulator.model.infrastructure;
+
+import ar.edu.unc.david.routersimulator.model.Packet;
+import java.util.ArrayDeque;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * A generic bounded or unbounded FIFO queue of {@link Packet}s.
+ *
+ * <p>A capacity of {@code 0} means unbounded — {@link #isFull()} always returns false and {@link
+ * #availableSpace()} returns {@link Integer#MAX_VALUE}.
+ */
+public class PacketBuffer {
+
+  private final ArrayDeque<Packet> packets;
+  private int capacity;
+
+  // =============== Constructors ===============
+
+  /** Unbounded buffer. */
+  public PacketBuffer() {
+    this(0);
+  }
+
+  /** Bounded if capacity > 0, unbounded if capacity == 0. */
+  public PacketBuffer(int capacity) {
+    if (capacity < 0) {
+      throw new IllegalArgumentException("capacity must be >= 0, got: " + capacity);
+    }
+    this.packets = new ArrayDeque<>();
+    this.capacity = capacity;
+  }
+
+  // =============== Getters ===============
+
+  public int capacity() {
+    return capacity;
+  }
+
+  public int size() {
+    return packets.size();
+  }
+
+  public boolean isEmpty() {
+    return packets.isEmpty();
+  }
+
+  public boolean isFull() {
+    return capacity != 0 && packets.size() >= capacity;
+  }
+
+  public int availableSpace() {
+    return capacity == 0 ? Integer.MAX_VALUE : capacity - packets.size();
+  }
+
+  public double utilization() {
+    return capacity == 0 ? 0.0 : (double) packets.size() / capacity;
+  }
+
+  // =============== Queue operations ===============
+
+  /**
+   * Adds the specified packet to the buffer if there is available space. If the buffer is full, the
+   * packet is not added.
+   *
+   * @param packet the packet to be enqueued into the buffer
+   * @return true if the packet was successfully enqueued, false if the buffer is full
+   */
+  public boolean enqueue(Packet packet) {
+    if (isFull()) {
+      return false;
+    }
+    packets.add(packet);
+    return true;
+  }
+
+  /**
+   * Removes and returns the packet at the head of the buffer.
+   *
+   * @return the packet that was removed from the head of the buffer
+   * @throws NoSuchElementException if the buffer is empty
+   */
+  public Packet dequeue() {
+    if (isEmpty()) {
+      throw new NoSuchElementException("Cannot dequeue from empty buffer");
+    }
+    return packets.removeFirst();
+  }
+
+  /**
+   * Retrieves, but does not remove, the head of the buffer (the first packet in the queue).
+   *
+   * @return the packet at the head of the buffer
+   * @throws NoSuchElementException if the buffer is empty
+   */
+  public Packet peek() {
+    if (isEmpty()) {
+      throw new NoSuchElementException("Cannot peek empty buffer");
+    }
+    return packets.peekFirst();
+  }
+
+  // =============== Buffer management ===============
+
+  /**
+   * Determines if the buffer contains a packet with the specified page ID and position.
+   *
+   * @param pageId the unique identifier of the page to check for.
+   * @param pagePos the position of the packet within the specified page.
+   * @return true if a packet with the specified page ID and position exists in the buffer, false
+   *     otherwise.
+   */
+  public boolean contains(long pageId, int pagePos) {
+    for (Packet p : packets) {
+      if (p.pageId() == pageId && p.pagePos() == pagePos) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Removes the packet at the specified index from the buffer.
+   *
+   * @param index the zero-based position of the packet to remove from the buffer
+   * @throws IndexOutOfBoundsException if the index is out of the range {@code 0 <= index < size()}
+   *     of the buffer
+   */
+  public void removeAt(int index) {
+    if (index < 0 || index >= packets.size()) {
+      throw new IndexOutOfBoundsException("Index out of range: " + index);
+    }
+    Iterator<Packet> it = packets.iterator();
+    for (int i = 0; i <= index; i++) {
+      it.next();
+    }
+    it.remove();
+  }
+
+  /**
+   * Updates the capacity of the packet buffer. The capacity determines the maximum number of
+   * packets that can be held in the buffer. A capacity of 0 indicates that the buffer is unbounded.
+   *
+   * @param newCapacity the new capacity of the buffer. Must be non-negative. If the buffer is
+   *     bounded (capacity > 0), and the new capacity is less than the current size of the buffer,
+   *     an {@code IllegalStateException} is thrown to prevent data loss.
+   * @throws IllegalArgumentException if {@code newCapacity} is negative.
+   * @throws IllegalStateException if {@code newCapacity > 0} and the buffer currently contains more
+   *     packets than the specified capacity.
+   */
+  public void setCapacity(int newCapacity) {
+    if (newCapacity < 0) {
+      throw new IllegalArgumentException("capacity must be >= 0");
+    }
+    if (newCapacity > 0 && packets.size() > newCapacity) {
+      throw new IllegalStateException(
+          "Cannot set capacity lower than current size (" + packets.size() + ")");
+    }
+    this.capacity = newCapacity;
+  }
+
+  public void clear() {
+    packets.clear();
+  }
+
+  // =============== toString ===============
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder("PacketBuffer{Usage: ").append(packets.size());
+    if (capacity > 0) {
+      sb.append("/").append(capacity);
+    }
+    sb.append(" packets}");
+    return sb.toString();
+  }
+}

--- a/src/test/java/ar/edu/unc/david/routersimulator/model/infrastructure/PacketBufferTest.java
+++ b/src/test/java/ar/edu/unc/david/routersimulator/model/infrastructure/PacketBufferTest.java
@@ -1,0 +1,178 @@
+package ar.edu.unc.david.routersimulator.model.infrastructure;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ar.edu.unc.david.routersimulator.model.IpAddress;
+import ar.edu.unc.david.routersimulator.model.Packet;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PacketBufferTest {
+
+  private static final IpAddress SRC = new IpAddress(1, 1);
+  private static final IpAddress DST = new IpAddress(2, 1);
+
+  private Packet makePacket(int pos, int len) {
+    return Packet.create(1L, pos, len, SRC, DST, 0L);
+  }
+
+  private PacketBuffer bounded;
+  private PacketBuffer unbounded;
+
+  @BeforeEach
+  void setUp() {
+    bounded = new PacketBuffer(3);
+    unbounded = new PacketBuffer();
+  }
+
+  @Test
+  void initialState_isEmpty() {
+    assertEquals(3, bounded.capacity());
+    assertEquals(0, bounded.size());
+    assertTrue(bounded.isEmpty());
+    assertFalse(bounded.isFull());
+    assertEquals(3, bounded.availableSpace());
+    assertEquals(0.0, bounded.utilization());
+  }
+
+  @Test
+  void unbounded_isNeverFull() {
+    assertFalse(unbounded.isFull());
+    assertEquals(Integer.MAX_VALUE, unbounded.availableSpace());
+  }
+
+  @Test
+  void unbounded_utilizationIsAlwaysZero() {
+    unbounded.enqueue(makePacket(0, 1));
+    assertEquals(0.0, unbounded.utilization());
+  }
+
+  @Test
+  void constructor_throwsOnNegativeCapacity() {
+    assertThrows(IllegalArgumentException.class, () -> new PacketBuffer(-1));
+  }
+
+  @Test
+  void enqueue_acceptsUpToCapacity() {
+    assertTrue(bounded.enqueue(makePacket(0, 3)));
+    assertTrue(bounded.enqueue(makePacket(1, 3)));
+    assertTrue(bounded.enqueue(makePacket(2, 3)));
+    assertFalse(bounded.enqueue(makePacket(0, 3)));
+    assertTrue(bounded.isFull());
+  }
+
+  @Test
+  void dequeue_returnsFifoOrder() {
+    bounded.enqueue(makePacket(0, 3));
+    bounded.enqueue(makePacket(1, 3));
+    assertEquals(0, bounded.dequeue().pagePos());
+    assertEquals(1, bounded.dequeue().pagePos());
+  }
+
+  @Test
+  void dequeue_throwsOnEmptyBuffer() {
+    assertThrows(NoSuchElementException.class, () -> bounded.dequeue());
+  }
+
+  @Test
+  void peek_doesNotRemovePacket() {
+    bounded.enqueue(makePacket(0, 3));
+    bounded.peek();
+    assertEquals(1, bounded.size());
+  }
+
+  @Test
+  void peek_throwsOnEmptyBuffer() {
+    assertThrows(NoSuchElementException.class, () -> bounded.peek());
+  }
+
+  @Test
+  void utilization_reflectsCurrentLoad() {
+    bounded.enqueue(makePacket(0, 3));
+    assertEquals(1.0 / 3.0, bounded.utilization(), 1e-9);
+  }
+
+  @Test
+  void contains_findsByPageIdAndPos() {
+    bounded.enqueue(makePacket(0, 3));
+    assertTrue(bounded.contains(1L, 0));
+    assertFalse(bounded.contains(1L, 1));
+    assertFalse(bounded.contains(99L, 0));
+  }
+
+  @Test
+  void removeAt_removesCorrectElement() {
+    bounded.enqueue(makePacket(0, 3));
+    bounded.enqueue(makePacket(1, 3));
+    bounded.enqueue(makePacket(2, 3));
+    bounded.removeAt(1);
+    assertEquals(2, bounded.size());
+    assertEquals(0, bounded.dequeue().pagePos());
+    assertEquals(2, bounded.dequeue().pagePos());
+  }
+
+  @Test
+  void removeAt_throwsOnOutOfBounds() {
+    assertThrows(IndexOutOfBoundsException.class, () -> bounded.removeAt(0));
+    assertThrows(IndexOutOfBoundsException.class, () -> bounded.removeAt(-1));
+  }
+
+  @Test
+  void setCapacity_reducesCapacity() {
+    bounded.enqueue(makePacket(0, 3));
+    bounded.setCapacity(2);
+    assertEquals(2, bounded.capacity());
+    assertFalse(bounded.isFull());
+  }
+
+  @Test
+  void setCapacity_increasesCapacity() {
+    bounded.setCapacity(5);
+    assertEquals(5, bounded.capacity());
+    assertFalse(bounded.isFull());
+  }
+
+  @Test
+  void setCapacity_toZeroMakesUnbounded() {
+    bounded.setCapacity(0);
+    assertFalse(bounded.isFull());
+    assertEquals(Integer.MAX_VALUE, bounded.availableSpace());
+  }
+
+  @Test
+  void setCapacity_throwsIfLowerThanCurrentSize() {
+    bounded.enqueue(makePacket(0, 3));
+    bounded.enqueue(makePacket(1, 3));
+    assertThrows(IllegalStateException.class, () -> bounded.setCapacity(1));
+  }
+
+  @Test
+  void setCapacity_throwsOnNegativeValue() {
+    assertThrows(IllegalArgumentException.class, () -> bounded.setCapacity(-1));
+  }
+
+  @Test
+  void clear_emptiesBuffer() {
+    bounded.enqueue(makePacket(0, 3));
+    bounded.clear();
+    assertTrue(bounded.isEmpty());
+  }
+
+  @Test
+  void toString_boundedBuffer() {
+    bounded.enqueue(makePacket(0, 3));
+    String str = bounded.toString();
+    assertTrue(str.contains("PacketBuffer{Usage: 1/3 packets}"));
+  }
+
+  @Test
+  void toString_unboundedBuffer() {
+    unbounded.enqueue(makePacket(0, 3));
+    String str = unbounded.toString();
+    assertTrue(str.contains("PacketBuffer{Usage: 1 packets}"));
+  }
+}

--- a/src/test/java/ar/edu/unc/david/routersimulator/service/PageReassemblerTest.java
+++ b/src/test/java/ar/edu/unc/david/routersimulator/service/PageReassemblerTest.java
@@ -120,6 +120,20 @@ class PageReassemblerTest {
     assertFalse(reassembler.addPacket(p));
   }
 
+  @Test
+  void hasPacketAt_returnsFalseForInvalidSlot() {
+    assertFalse(reassembler.hasPacketAt(0));
+    assertThrows(IndexOutOfBoundsException.class, () -> reassembler.hasPacketAt(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> reassembler.hasPacketAt(TOTAL));
+  }
+
+  @Test
+  void hasPacketAt_returnsTrueForValidSlot() {
+    var p = Packet.create(PAGE_ID, 0, TOTAL, SRC, DST, 0L);
+    assertTrue(reassembler.addPacket(p));
+    assertTrue(reassembler.hasPacketAt(0));
+  }
+
   // =============== isComplete / completionRate ===============
 
   @Test
@@ -170,6 +184,12 @@ class PageReassemblerTest {
   void equals_basedOnlyOnPageId() {
     var other = new PageReassembler(PAGE_ID, new IpAddress(9, 9), 5, 999L);
     assertEquals(reassembler, other);
+  }
+
+  @Test
+  void equals_differentPageIdsNotEqual() {
+    var other = new PageReassembler(999L, SRC, TOTAL, 0L);
+    assertNotEquals(reassembler, other);
   }
 
   // =============== hashCode ===============


### PR DESCRIPTION
This pull request introduces a new `PacketBuffer` class for managing packets in a FIFO queue, along with comprehensive unit tests for its functionality. Additionally, it expands the test coverage for the `PageReassembler` class by adding tests for slot validity and equality logic.

New infrastructure: Packet buffer

* Added the `PacketBuffer` class in `PacketBuffer.java`, providing a generic bounded or unbounded FIFO queue for `Packet` objects with methods for enqueue, dequeue, peek, capacity management, and buffer inspection.

Test coverage improvements

* Introduced `PacketBufferTest.java` with thorough unit tests covering all buffer operations, edge cases, and error handling for the new `PacketBuffer` class.
* Added tests in `PageReassemblerTest.java` to verify `hasPacketAt()` returns correct results for valid and invalid slots, including out-of-bounds checks.
* Added a test in `PageReassemblerTest.java` to ensure `equals()` returns false for instances with different page IDs, improving equality logic coverage.