### PR TITLE
feat: update `Main` class to initialize and run simulation

### DIFF
--- a/src/main/java/ar/edu/unc/david/routersimulator/Main.java
+++ b/src/main/java/ar/edu/unc/david/routersimulator/Main.java
@@ -1,11 +1,31 @@
 package ar.edu.unc.david.routersimulator;
 
+import ar.edu.unc.david.routersimulator.model.core.Admin;
+import ar.edu.unc.david.routersimulator.model.core.Network;
+
 /**
- * TIP To <b>Run</b> code, press <shortcut actionId="Run"/> or click the <icon
- * src="AllIcons.Actions.Execute"/> icon in the gutter.
+ * The Main class serves as the entry point for the program execution. It initializes the necessary
+ * components and orchestrates the simulation run.
+ *
+ * <p>Responsibilities of this class: - Create and configure the Network instance. - Initiate and
+ * manage the Admin instance to control the simulation. - Display the final report after the
+ * simulation is completed.
  */
 public class Main {
 
-  /** Entry point of the application. */
-  public static void main(String[] args) {}
+  /**
+   * The main method serves as the entry point for the program execution. It initializes the
+   * simulation environment, runs the simulation, and outputs the final report.
+   *
+   * @param args command-line arguments passed to the program
+   */
+  public static void main(String[] args) {
+    Network network = new Network();
+    Admin admin = new Admin(network);
+
+    admin.runFor(100, 10);
+
+    System.out.println("\n=== FINAL REPORT ===");
+    admin.printReport();
+  }
 }


### PR DESCRIPTION
This pull request enhances the `Main` class to provide a functional entry point for the router simulator application. It now initializes the core simulation components, runs the simulation, and outputs a final report. The main method is no longer empty and contains clear responsibilities.

Simulation setup and execution:

* Added instantiation of `Network` and `Admin` objects in the `main` method, establishing the simulation environment.
* The simulation is now executed by calling `admin.runFor(100, 10)`, which presumably runs the simulation for 100 units with a step of 10.

Reporting:

* After the simulation, the program prints a final report by calling `admin.printReport()`.

Documentation:

* Improved class and method documentation to clearly state the responsibilities and flow of the `Main` class.